### PR TITLE
Shortened Cult Application

### DIFF
--- a/docs/training/cult-app-pocket
+++ b/docs/training/cult-app-pocket
@@ -1,0 +1,45 @@
+---
+layout: default
+title: Pocket Cult Application
+parent: Cult
+grand_parent: Training
+nav_order: 2
+---
+
+# ❋ Chaos Indivisvm Application (P) v.1.00❋
+{: .no_toc }
+
+Chaos Indivisvm is located at **Milopolis**
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+# The Application
+
+Hello! This is the Chaos Indivisvm POCKET APPLICATION. If you choose to fill this form out, you will be expected to be interviewed before you are considered to join Chaos Indivisvm's cult.
+
+Your avatar name (NOT display name!):
+
+Your avatar age:
+
+Your REAL LIFE age:
+
+Your Time Zone:
+
+When are you usually online?:
+
+DELIVER APPLICATION TO:
+
++ Zalera Atheria
+
+** If you are not contacted 24 hours please IM Zalera for an update, THEN feel free to send your app to ONE of the following accounts:
+
++ Hadet Sonnenkern
+
++ Sam Huntsman
+
+Recruitment Application (P) v.1.00
+Created 8/31/2021, modified from existing cult application v.9.21


### PR DESCRIPTION
So instead of just proposing we replace the application or "fix what's broken", we just have two applications for something Rachel wants to try and might be easier on both cultists to speed up the process and make following up on apps more interesting. The goal here is to shorten the application to essential information and then to have the potential cultist be interviewed, which could also lead into finding their gear. The questions during the interview could either be a separate document or just filling out the non-junk questions on the normal application for the interviewer, which we retain for record-keeping.

Due to the length of this application, we could add in a web-interface and even have some kind of media-app experience inworld, but you guys have said you don't like that so here's a compromise.